### PR TITLE
Quick test: pass all FS events.

### DIFF
--- a/daemon/process/inotify/watch.go
+++ b/daemon/process/inotify/watch.go
@@ -35,7 +35,7 @@ func (d *defaultWatcher) Watch(ctx context.Context, dirs []string, mod chan<- mo
 		if err != nil {
 			return fmt.Errorf("invalid directory: %w", err)
 		}
-		err = notify.Watch(dir+"...", c, notify.Write)
+		err = notify.Watch(dir+"...", c, notify.All)
 		if err != nil {
 			return fmt.Errorf("error watching directory recursively '%s': %w", dir, err)
 		}


### PR DESCRIPTION
Pass all received FS events (as opposed to just writes) through to the daemon.
This is the cheapest possible change, just to verify that it would fit my use case.  Will need an option if it does.